### PR TITLE
Compile the project on the postinstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/coverage
 **/node_modules
 **/.eslintcache
+*.js

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@vendoo/contract-testing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Contract Testing made easy",
-  "main": "src/index.ts",
+  "main": "src/index.js",
   "repository": "git@github.com:vendoo/contract-testing.git",
   "author": "Tiago Miranda <tiago@vendoo.co>",
   "license": "MIT",
@@ -11,6 +11,7 @@
     "eslint:cli": "eslint --ext ts,tsx -f codeframe --cache",
     "eslint": "yarn run eslint:cli . --quiet",
     "test": "jest --passWithNoTests",
+    "postinstall": "yarn run tsc",
     "test:tsc": "echo '@vendoo/common'; tsc --noEmit -p ./tsconfig.json --skipLibCheck",
     "test:watch": "jest --watch",
     "cover": "jest --coverage",


### PR DESCRIPTION
Compile the project on the Postinstall
---

Some projects do not support importing Typescript files, this is the case of the Enterprise scripts, which use the `ts-node` and it does not support the TypeScript import from node_modules.

Because of that, we decided (along with @mtxr) to compile the project in the post-install to avoid any issues in the future since we have seen the same error a few times already.

To make it work we have added a `postinstall` script to the package.json and also `*.js` files in the `.gitignore` files.